### PR TITLE
Sync recipes from internal repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<maven.compiler.release>17</maven.compiler.release>
 		<jar.finalName>${project.artifactId}-${project.version}</jar.finalName>
 
-		<httpclient-version>5.6</httpclient-version>
+		<httpclient-version>5.6.1</httpclient-version>
 		<jackson-version>2.21.2</jackson-version>
 		<jackson-annotations-version>2.21</jackson-annotations-version>
 		<jackson-databind-version>2.21.1</jackson-databind-version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<jackson-version>2.21.1</jackson-version>
 		<jackson-annotations-version>2.21</jackson-annotations-version>
 		<jackson-databind-version>2.21.1</jackson-databind-version>
-		<jackson-databind-nullable-version>0.2.8</jackson-databind-nullable-version>
+		<jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
 		<jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 		<lombok.version>1.18.42</lombok.version>
 		<commons-lang3.version>3.20.0</commons-lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<!-- Plugins -->
 		<maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
 		<maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
-		<maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
+		<maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<dotenv-java.version>3.2.0</dotenv-java.version>
 		<slf4j-api.version>2.0.17</slf4j-api.version>
 		<logback-classic.version>1.5.32</logback-classic.version>
-		<primary-api-client.version>1.3.59</primary-api-client.version>
+		<primary-api-client.version>1.3.64</primary-api-client.version>
 
 		<!-- Plugins -->
 		<maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<jackson-databind-version>2.21.1</jackson-databind-version>
 		<jackson-databind-nullable-version>0.2.8</jackson-databind-nullable-version>
 		<jakarta-annotation-version>3.0.0</jakarta-annotation-version>
-		<lombok.version>1.18.42</lombok.version>
+		<lombok.version>1.18.44</lombok.version>
 		<commons-lang3.version>3.20.0</commons-lang3.version>
 		<commons-text.version>1.15.0</commons-text.version>
 		<httpclient5.version>5.5</httpclient5.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<dotenv-java.version>3.2.0</dotenv-java.version>
 		<slf4j-api.version>2.0.17</slf4j-api.version>
 		<logback-classic.version>1.5.32</logback-classic.version>
-		<primary-api-client.version>1.3.67</primary-api-client.version>
+		<primary-api-client.version>1.3.70</primary-api-client.version>
 
 		<!-- Plugins -->
 		<maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<jar.finalName>${project.artifactId}-${project.version}</jar.finalName>
 
 		<httpclient-version>5.6</httpclient-version>
-		<jackson-version>2.21.1</jackson-version>
+		<jackson-version>2.21.2</jackson-version>
 		<jackson-annotations-version>2.21</jackson-annotations-version>
 		<jackson-databind-version>2.21.1</jackson-databind-version>
 		<jackson-databind-nullable-version>0.2.8</jackson-databind-nullable-version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<dotenv-java.version>3.2.0</dotenv-java.version>
 		<slf4j-api.version>2.0.17</slf4j-api.version>
 		<logback-classic.version>1.5.32</logback-classic.version>
-		<primary-api-client.version>1.3.64</primary-api-client.version>
+		<primary-api-client.version>1.3.67</primary-api-client.version>
 
 		<!-- Plugins -->
 		<maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<primary-api-client.version>1.3.70</primary-api-client.version>
 
 		<!-- Plugins -->
-		<maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
+		<maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
 		<maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
 		<maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
 	</properties>

--- a/src/main/java/com/monarkmarkets/InvestorRecipes.java
+++ b/src/main/java/com/monarkmarkets/InvestorRecipes.java
@@ -132,7 +132,13 @@ public class InvestorRecipes {
 										value = "No options available";
 									}
 								}
-								case BOOLEAN -> value = "true";
+								case BOOLEAN -> {
+									if (question.getOptions() != null && !question.getOptions().isEmpty()) {
+										value = question.getOptions().get(random.nextInt(question.getOptions().size()));
+									} else {
+										value = "true";
+									}
+								}
 								case DATE -> {
 									// Random date within the last year
 									LocalDate randomDate = LocalDate.now().minusDays(random.nextInt(365));

--- a/src/main/java/com/monarkmarkets/InvestorSubscriptionRecipes.java
+++ b/src/main/java/com/monarkmarkets/InvestorSubscriptionRecipes.java
@@ -113,7 +113,7 @@ public class InvestorSubscriptionRecipes {
 	private static PreIPOCompanySPV choosePreIPOCompanySPV(List<PreIPOCompanySPV> preIPOCompanySPVS) {
 		List<PreIPOCompanySPV> eligibleSPVs = preIPOCompanySPVS.stream()
 				.filter(spv -> spv.getRemainingShareAllocation() > 0 &&
-						spv.getRemainingDollarAllocation() > 0 &&
+						spv.getRemainingDollarAllocation() >= 1.0 &&
 						spv.getNumberOfSeatsRemaining() > 0 &&
 						spv.getMonarkStage() == PRIMARY_FUNDRAISE &&
 						TRUE.equals(spv.getIsApproved()))

--- a/src/main/java/com/monarkmarkets/InvestorSubscriptionTransactionRecipes.java
+++ b/src/main/java/com/monarkmarkets/InvestorSubscriptionTransactionRecipes.java
@@ -115,11 +115,11 @@ public class InvestorSubscriptionTransactionRecipes {
 	 * This flow describes the creation and rejection of a Subscription on the primary market using the new unified
 	 * Transaction API.
 	 */
-	public static Transaction submitAndRejectInvestorSubscription(UUID investorId) {
+	public static Transaction submitAndRejectInvestorSubscription(UUID investorId, UUID excludeSpvId) {
 		// Step 1: Get a PreIPOCompanySPV
 		// SPVs can only accept Subscriptions from Investors when the MonarkStage field is set to PRIMARY_FUNDRAISE
 		List<PreIPOCompanySPV> preIPOCompanySPVs = getAllPreIPOCompanySPVs(investorId);
-		PreIPOCompanySPV preIPOCompanySPV = choosePreIPOCompanySPV(preIPOCompanySPVs);
+		PreIPOCompanySPV preIPOCompanySPV = choosePreIPOCompanySPV(preIPOCompanySPVs, excludeSpvId);
 		log.info("PreIPOCompanySPV: {}", preIPOCompanySPV);
 
 		// Step 1.1: Calculate the Subscription Amount based on the subscription rules
@@ -143,12 +143,17 @@ public class InvestorSubscriptionTransactionRecipes {
 	}
 
 	private static PreIPOCompanySPV choosePreIPOCompanySPV(List<PreIPOCompanySPV> preIPOCompanySPVS) {
+		return choosePreIPOCompanySPV(preIPOCompanySPVS, null);
+	}
+
+	private static PreIPOCompanySPV choosePreIPOCompanySPV(List<PreIPOCompanySPV> preIPOCompanySPVS, UUID excludeSpvId) {
 		List<PreIPOCompanySPV> eligibleSPVs = preIPOCompanySPVS.stream()
 				.filter(spv -> spv.getRemainingShareAllocation() > 0 &&
 						spv.getRemainingDollarAllocation() > 0 &&
 						spv.getNumberOfSeatsRemaining() > 0 &&
 						spv.getMonarkStage() == PRIMARY_FUNDRAISE &&
 						TRUE.equals(spv.getIsApproved()))
+				.filter(spv -> excludeSpvId == null || !excludeSpvId.equals(spv.getId()))
 				.toList();
 
 		if (eligibleSPVs.isEmpty()) {

--- a/src/main/java/com/monarkmarkets/InvestorSubscriptionTransactionRecipes.java
+++ b/src/main/java/com/monarkmarkets/InvestorSubscriptionTransactionRecipes.java
@@ -149,7 +149,7 @@ public class InvestorSubscriptionTransactionRecipes {
 	private static PreIPOCompanySPV choosePreIPOCompanySPV(List<PreIPOCompanySPV> preIPOCompanySPVS, UUID excludeSpvId) {
 		List<PreIPOCompanySPV> eligibleSPVs = preIPOCompanySPVS.stream()
 				.filter(spv -> spv.getRemainingShareAllocation() > 0 &&
-						spv.getRemainingDollarAllocation() > 0 &&
+						spv.getRemainingDollarAllocation() >= 1.0 &&
 						spv.getNumberOfSeatsRemaining() > 0 &&
 						spv.getMonarkStage() == PRIMARY_FUNDRAISE &&
 						TRUE.equals(spv.getIsApproved()))

--- a/src/main/java/com/monarkmarkets/Recipes.java
+++ b/src/main/java/com/monarkmarkets/Recipes.java
@@ -9,6 +9,8 @@ import static com.monarkmarkets.IndicationOfInterestRecipesV2.submitIndicationOf
 import static com.monarkmarkets.InvestorRecipes.investorOnboarding;
 import static com.monarkmarkets.InvestorSubscriptionTransactionRecipes.submitAndRejectInvestorSubscription;
 import static com.monarkmarkets.InvestorSubscriptionTransactionRecipes.submitInvestorSubscription;
+
+import java.util.UUID;
 import static com.monarkmarkets.PostCloseAccountViewRecipes.postCloseAccountView;
 import static com.monarkmarkets.RegisteredFundTransactionRecipes.submitRegisteredFundSubscription;
 
@@ -38,8 +40,9 @@ public class Recipes {
 		Transaction investorSubscriptionTransaction = submitInvestorSubscription(investor.getId());
 		log.info("InvestorSubscriptionTransaction: {}", investorSubscriptionTransaction);
 
-		// Reject Investor Subscription
-		Transaction rejectedInvestorSubscriptionTransaction = submitAndRejectInvestorSubscription(investor.getId());
+		// Reject Investor Subscription (exclude the SPV used above to avoid 409 conflict)
+		UUID usedSpvId = investorSubscriptionTransaction.getTargetId();
+		Transaction rejectedInvestorSubscriptionTransaction = submitAndRejectInvestorSubscription(investor.getId(), usedSpvId);
 		log.info("Rejected InvestorSubscriptionTransaction: {}", rejectedInvestorSubscriptionTransaction);
 
 		// Execute Post-Close Account View

--- a/src/main/java/com/monarkmarkets/RegisteredFundTransactionRecipes.java
+++ b/src/main/java/com/monarkmarkets/RegisteredFundTransactionRecipes.java
@@ -488,7 +488,7 @@ public class RegisteredFundTransactionRecipes {
 	private static Questionnaire getQuestionnaireById(UUID questionnaireId, UUID investorId) {
 		try {
 			log.info("Get questionnaire by id: {} for investor: {}", questionnaireId, investorId);
-			return questionnaireApi.getQuestionnaireById(questionnaireId, investorId, null);
+			return questionnaireApi.getQuestionnaireById(questionnaireId, investorId, null, null);
 		} catch (ApiException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/main/java/com/monarkmarkets/RegisteredFundTransactionRecipes.java
+++ b/src/main/java/com/monarkmarkets/RegisteredFundTransactionRecipes.java
@@ -147,7 +147,13 @@ public class RegisteredFundTransactionRecipes {
 									value = "No options available";
 								}
 							}
-							case BOOLEAN -> value = "true";
+							case BOOLEAN -> {
+								if (question.getOptions() != null && !question.getOptions().isEmpty()) {
+									value = question.getOptions().get(random.nextInt(question.getOptions().size()));
+								} else {
+									value = "true";
+								}
+							}
 							case DATE -> {
 								// Random date within the last year
 								LocalDate randomDate = LocalDate.now().minusDays(random.nextInt(365));

--- a/src/main/java/com/monarkmarkets/SubscriptionCalculator.java
+++ b/src/main/java/com/monarkmarkets/SubscriptionCalculator.java
@@ -39,7 +39,7 @@ public class SubscriptionCalculator {
 		double pricePerShare = spv.getAllInPricePerShare();
 		double minCommitment = spv.getMinCommitmentAmount();
 
-		if (remainingShares <= 0.0 || remainingDollars <= 0.0 || pricePerShare <= 0.0 || minCommitment <= 0.0) {
+		if (remainingShares <= 0.0 || remainingDollars < 1.0 || pricePerShare <= 0.0 || minCommitment <= 0.0) {
 			throw new IllegalArgumentException("SPV contains invalid or insufficient data.");
 		}
 


### PR DESCRIPTION
## Summary

Sync latest recipe changes from the internal repository, including dependency updates merged via Dependabot on the internal side and recent fixes.

### Dependency bumps (from internal Dependabot PRs)
- `jackson-version` 2.21.1 → 2.21.2
- `jackson-databind-nullable` 0.2.8 → 0.2.10
- `lombok` 1.18.42 → 1.18.44
- `maven-compiler-plugin` 3.14.1 → 3.15.0
- `maven-shade-plugin` 3.6.1 → 3.6.2
- `primary-api-client` 1.3.59 → 1.3.70

### Recipe changes
- Fix intermittent SPV creation issues (exclude used SPV from reject flow + bump SDK to 1.3.64)
- Fix intermittent 400 error sending incorrect value on `amountReservedDollars`
- Fix boolean options in questionnaires
- Related touch-ups in `InvestorRecipes`, `InvestorSubscriptionRecipes`, `InvestorSubscriptionTransactionRecipes`, `Recipes`, `RegisteredFundTransactionRecipes`, `SubscriptionCalculator`

The httpclient5 dependabot bump previously merged on the public repo (PR #20) has already been reconciled into `public-main`, so there's no conflict with that change.