### PR TITLE
Bump Jackson to 2.22.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     
     - name: Set up JDK 17
       uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
 		<jar.finalName>${project.artifactId}-${project.version}</jar.finalName>
 
 		<httpclient-version>5.6.1</httpclient-version>
-		<jackson-version>2.21.2</jackson-version>
-		<jackson-annotations-version>2.21</jackson-annotations-version>
-		<jackson-databind-version>2.21.1</jackson-databind-version>
+		<jackson-version>2.22.1</jackson-version>
+		<jackson-annotations-version>2.22</jackson-annotations-version>
+		<jackson-databind-version>2.22.1</jackson-databind-version>
 		<jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
 		<jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 		<lombok.version>1.18.44</lombok.version>


### PR DESCRIPTION
Bumps Jackson runtime dependencies to 2.22.1 to address the jackson-databind advisory range and updates actions/checkout to v7.