### PR TITLE
Resolve stale Dependabot dependency PRs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
 		<jackson-databind-version>2.22.1</jackson-databind-version>
 		<jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
 		<jakarta-annotation-version>3.0.0</jakarta-annotation-version>
-		<lombok.version>1.18.44</lombok.version>
+		<lombok.version>1.18.46</lombok.version>
 		<commons-lang3.version>3.20.0</commons-lang3.version>
 		<commons-text.version>1.15.0</commons-text.version>
 		<httpclient5.version>5.5</httpclient5.version>
-		<httpcore5.version>5.4.1</httpcore5.version>
+		<httpcore5.version>5.4.3</httpcore5.version>
 		<dotenv-java.version>3.2.0</dotenv-java.version>
 		<slf4j-api.version>2.0.17</slf4j-api.version>
 		<logback-classic.version>1.5.32</logback-classic.version>


### PR DESCRIPTION
Updates the public recipe dependencies to supersede the open Dependabot PRs: Lombok 1.18.46 and httpcore5 5.4.3. The Jackson PRs are already superseded by Jackson 2.22.1 on main.